### PR TITLE
Allow SVG as if XML

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (opts) {
   opts.preserveComments = opts.hasOwnProperty('preserveComments') ? opts.preserveComments : false;
   opts.verbose = process.argv.indexOf('--verbose') !== -1;
 
-  var validExts    = ['xml', 'json', 'css', 'sql'];
+  var validExts    = ['xml', 'svg', 'json', 'css', 'sql'];
   var methodSuffix = opts.type === 'minify' ? 'min' : '';
 
   return through.obj(function (file, enc, cb) {
@@ -42,6 +42,7 @@ module.exports = function (opts) {
     }
 
     try {
+      fileExt = (fileExt === 'svg') ? 'xml' : fileExt;
       file.contents = new Buffer(pd[fileExt+methodSuffix](String(file.contents), opts.preserveComments));
     } catch (err) {
       return cb(new gutil.PluginError('gulp-pretty-data', err, opts));

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var pd      = require('pretty-data').pd;
 var gutil   = require('gulp-util');
 var path    = require('path');
 var through = require('through2');
+var chalk   = require('chalk');
 
 module.exports = function (opts) {
 


### PR DESCRIPTION
This PR allows `.svg` extension files to be handled as `.xml`;
it also fixes the missing require to `chalk` in `index.js`.

Cheers for the plugin
