### PR TITLE
allow support for custom file extentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@ Install the module with: `npm install gulp-pretty-data --save-dev`
 ## Usage
 
 ```js
-var gulp = require('gulp');
+var gulp       = require('gulp');
 var prettyData = require('gulp-pretty-data');
 
 gulp.task('minify', function() {
-  gulp.src('src/**.{xml,json}')
-    .pipe(prettyData({type: 'minify', preserveComments: true}))
+  gulp.src('src/**.{xml,json,xlf,svg}')
+    .pipe(prettyData({
+      type: 'minify',
+      preserveComments: true,
+      extensions: {
+        'xlf': 'xml',
+        'svg': 'xml'
+      }
+    }))
     .pipe(gulp.dest('dist'))
 });
 

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -2,7 +2,7 @@ var gulp = require('gulp');
 var prettyData = require('../');
 
 gulp.task('minify', function(){
-  gulp.src('./src/**.{json,xml}')
+  gulp.src('./src/*.{json,xml}')
   .pipe(prettyData({
   	type: 'minify',
   	preserveComments: true
@@ -11,9 +11,19 @@ gulp.task('minify', function(){
 });
 
 gulp.task('pretty', function(){
-  gulp.src('./src/**.{json,xml}')
+  gulp.src('./src/*.{json,xml}')
   .pipe(prettyData({
   	type: 'prettify'
+  }))
+  .pipe(gulp.dest('./build'));
+});
+
+gulp.task('xliff', function(){
+  console.log(process.argv);
+  gulp.src('./src/*.xlf')
+  .pipe(prettyData({
+    extensions: {'xlf': 'xml'},
+    type: 'prettify'
   }))
   .pipe(gulp.dest('./build'));
 });

--- a/examples/src/messages.xlf
+++ b/examples/src/messages.xlf
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file source-language="en" datatype="plaintext" original="ng2.template">
+<body>
+      <trans-unit id="f65253954b66e929a8b4d5ecaf61f9129f8cec64" datatype="html">
+        <source>Dashboard</source>
+        <target/>
+      </trans-unit>
+      <trans-unit id="6765b4c916060f6bc42d9bb69e80377dbcb5e4e9" datatype="html">
+        <source>Login</source>
+        <target/>
+  </trans-unit>
+      <trans-unit id="cfc2f436ec2beffb042e7511a73c89c372e86a6c" datatype="html">
+        <source>Register</source>
+        <target/>
+      </trans-unit>
+         <trans-unit id="831f1065c703ea0cbbd418cc25837966315ba640" datatype="html">
+        <source>User Profile</source>
+           <target/>
+</trans-unit>
+ <trans-unit id="099c55bb2d1dde094a44462957eb49d004099832" datatype="html">
+        <source>All rights reserved.</source>
+        <target/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = function (opts) {
   }
 
   opts.preserveComments = opts.hasOwnProperty('preserveComments') ? opts.preserveComments : false;
+  opts.extensions = opts.hasOwnProperty('extensions') ? opts.extensions : {};
   opts.verbose = process.argv.indexOf('--verbose') !== -1;
 
   var validExts    = ['xml', 'json', 'css', 'sql'];
@@ -20,6 +21,7 @@ module.exports = function (opts) {
   return through.obj(function (file, enc, cb) {
 
     var fileExt = path.extname(file.path).toLowerCase().substr(1);
+    fileExt = fileExt in opts.extensions ? opts.extensions[fileExt] : fileExt;
 
     if (file.isNull()) {
       cb(null, file);


### PR DESCRIPTION
This merge suggests an addition of optional option called `extensions`, which would allow users to map their own file formats like for example `svg` to the list of supported file extensions i.e. `xml, json, css, sql`:

```js
var gulp       = require('gulp');
var prettyData = require('gulp-pretty-data');

gulp.task('minify-svg', function() {
  gulp.src('src/*.svg')
    .pipe(prettyData({
      type: 'minify',
      preserveComments: true,
      extensions: {
        'svg': 'xml'
      }
    }))
    .pipe(gulp.dest('dist'))
});
```

This would close issues #1 and #4.