### PR TITLE
using version 0.1.2 for no gulp-util dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-pretty-data",
   "description": "Gulp plugin to minify or prettify xml, json, css, sql",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "homepage": "https://github.com/neilcarpenter/gulp-pretty-data",
   "author": {


### PR DESCRIPTION
Hi there

Just a simple request to create version 0.1.2 so that npm can start using the version without gulp-util dependencies.

Can you also please publish to npm?